### PR TITLE
feat(auth): BEE-1687 HttpKeyStore + Cloud Function validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ infra/*.tfstate.backup
 infra/*.tfplan
 infra/terraform.tfvars
 infra/.terraform.lock.hcl
+
+# clangd index
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,22 @@ if(BEEPBOX_BUILD_SERVER)
   )
   FetchContent_MakeAvailable(drogon)
 
+  # cpp-httplib for outgoing HTTPS (HttpKeyStore validator). Header-only,
+  # uses OpenSSL which Drogon already pulls in.
+  FetchContent_Declare(
+    cpp-httplib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+    GIT_TAG        v0.18.3
+    GIT_SHALLOW    TRUE
+  )
+  FetchContent_MakeAvailable(cpp-httplib)
+
+  find_package(OpenSSL REQUIRED)
+
   add_executable(beepbox-server
     src/server_main.cpp
     src/ApiKeyAuth.cpp
+    src/HttpKeyStoreFactory.cpp
     src/RateLimiter.cpp
     src/Metrics.cpp
     src/Tracing.cpp
@@ -157,6 +170,9 @@ if(BEEPBOX_BUILD_SERVER)
   target_link_libraries(beepbox-server PRIVATE
     beepbox_lib
     drogon
+    httplib::httplib
+    OpenSSL::SSL
+    OpenSSL::Crypto
   )
 endif()
 
@@ -204,6 +220,7 @@ if(BUILD_TESTING)
     tests/RoundTripTests.cpp
     tests/ConcurrencyTests.cpp
     tests/ApiKeyAuthTests.cpp
+    tests/HttpKeyStoreTests.cpp
     tests/RateLimiterTests.cpp
     tests/MetricsTests.cpp
     tests/TracingTests.cpp

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -1,0 +1,56 @@
+# 💡 Ideas
+
+Captura **ideas no maduras**: brainstorms, "what if we...", spikes pendientes
+de explorar, ocurrencias que no son aún una tarea formal.
+
+🌱 **Aquí entra**: cualquier ocurrencia, incluso si suena rara — todas son bienvenidas.
+🚫 **Aquí NO entra**: trabajo ya decidido y agendado a un milestone (eso va a Linear).
+
+🪄 **Promoción**: ponerle un milestone a una idea la convierte en task Linear
+`BEE-XXXX` y se elimina automáticamente de este fichero.
+
+---
+
+## 📋 Cómo añadir una idea
+
+Usa el skill `/ideas` (recomendado). O copia este bloque al final del fichero:
+
+```markdown
+### 💡 idea-NNN — [Título corto]
+
+- 📅 **Fecha**: YYYY-MM-DD
+- 🏷️ **Tipo**: feat | fix | docs | refactor | chore | infra | security | test
+- 🧭 **Contexto**: una frase de por qué surgió
+- 🎯 **Idea**: lo que se propone
+- 📝 **Notas**: detalles adicionales (opcional)
+- 🚦 **Estado**: 🌱 Nueva
+```
+
+### 🏷️ Tipos disponibles
+
+| Tipo | Cuándo usarlo |
+|------|---------------|
+| `feat` | Funcionalidad nueva |
+| `fix` | Bug fix |
+| `docs` | Solo documentación |
+| `refactor` | Refactor sin cambio de comportamiento |
+| `chore` | Mantenimiento, deps, config |
+| `infra` | Infraestructura, CI/CD |
+| `security` | Cuestiones de seguridad |
+| `test` | Solo tests |
+
+### 🚦 Estados posibles
+
+| Iconito | Estado | Significado |
+|---------|--------|-------------|
+| 🌱 | Nueva | Recién capturada, sin discusión |
+| 🔄 | En discusión | Hablándose |
+| 📋 | Promovida | Ya es task Linear (`BEE-XXXX`) — debería haberse eliminado de aquí |
+| 🧊 | En hielo | Buena idea pero no es momento |
+| ❌ | Descartada | Decidido no avanzar (apuntar el porqué) |
+
+---
+
+## 🗂️ Ideas registradas
+
+> _Aún no hay ideas. Añade la primera con `/ideas`._

--- a/docs/PENDING.md
+++ b/docs/PENDING.md
@@ -1,0 +1,57 @@
+# ⏳ Pending
+
+Captura **trabajo conocido pero aún sin fecha** — el "lo haremos algún día pero
+no ahora".
+
+🎯 **Aquí entra**: deuda detectada, follow-ups de incidentes, feedback accionable,
+"esto hay que hacerlo pero no hemos decidido cuándo".
+🚫 **Aquí NO entra**: trabajo ya agendado a un milestone (eso va a Linear).
+
+🪄 **Promoción**: ponerle un milestone a un pending lo convierte en task Linear
+`BEE-XXXX` y se elimina automáticamente de este fichero.
+
+---
+
+## 📋 Cómo añadir un pending
+
+Usa el skill `/pending` (recomendado). O copia este bloque al final del fichero:
+
+```markdown
+### ⏳ pending-NNN — [Título corto]
+
+- 📅 **Fecha añadida**: YYYY-MM-DD
+- 🏷️ **Tipo**: feat | fix | docs | refactor | chore | infra | security | test
+- 🧭 **Trigger**: por qué se añadió (incidente, feedback, deuda)
+- ⚙️ **Acción requerida**: qué hay que hacer concretamente
+- 🚧 **Bloqueado por**: (si aplica) algo o alguien que retrasa
+- 🚦 **Estado**: 🆕 Nuevo
+```
+
+### 🏷️ Tipos disponibles
+
+| Tipo | Cuándo usarlo |
+|------|---------------|
+| `feat` | Funcionalidad nueva |
+| `fix` | Bug fix |
+| `docs` | Solo documentación |
+| `refactor` | Refactor sin cambio de comportamiento |
+| `chore` | Mantenimiento, deps, config |
+| `infra` | Infraestructura, CI/CD |
+| `security` | Cuestiones de seguridad |
+| `test` | Solo tests |
+
+### 🚦 Estados posibles
+
+| Iconito | Estado | Significado |
+|---------|--------|-------------|
+| 🆕 | Nuevo | Recién capturado, sin triage |
+| 🔍 | En triage | Decidiendo prioridad / scope |
+| 📋 | Promovido | Ya es task Linear (`BEE-XXXX`) — debería haberse eliminado de aquí |
+| 🚧 | Bloqueado | Esperando algo externo (especificar) |
+| ❌ | No procede | Decidido no avanzar (apuntar el porqué) |
+
+---
+
+## 🗂️ Pendientes registrados
+
+> _Aún no hay pendings. Añade el primero con `/pending`._

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -82,6 +82,7 @@ Available at `GET /metrics` in Prometheus exposition format.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BEEPBOX_API_KEYS` | *(none)* | Comma-separated API keys (auth disabled if unset) |
+| `BEEPBOX_AUTH_ENDPOINT` | *(none)* | HTTPS URL of a validator returning `{"valid": bool, "ownerUid": string}` for a given `bk_` key. Takes precedence over `BEEPBOX_API_KEYS`. Used in prod/dev against a Firebase Cloud Function. |
+| `BEEPBOX_API_KEYS` | *(none)* | Fallback for local dev: comma-separated static list of valid `bk_` keys. Used only if `BEEPBOX_AUTH_ENDPOINT` is unset. |
 | `BEEPBOX_RATE_LIMIT_RPM` | *(none)* | Requests per minute per key (disabled if unset) |
 | `GCP_PROJECT_ID` | *(none)* | Used to format Cloud Trace resource names |

--- a/include/beepbox/HttpKeyStore.h
+++ b/include/beepbox/HttpKeyStore.h
@@ -1,0 +1,46 @@
+#ifndef BEEPBOX_HTTP_KEY_STORE_H
+#define BEEPBOX_HTTP_KEY_STORE_H
+
+#include <functional>
+#include <string>
+
+#include "beepbox/ApiKeyAuth.h"
+
+namespace beepbox {
+
+/// KeyStore that delegates validation to an injected callable.
+///
+/// The callable takes a raw key (e.g. "bk_XXXXXX") and returns true iff the
+/// key is currently valid. Implementations backed by a remote HTTP service
+/// MUST fail closed (return false) on network/timeout/5xx errors.
+///
+/// Production code uses `makeHttpKeyStoreFromEndpoint()` to build one backed
+/// by a POST to a Cloud Function validator; tests inject a lambda directly.
+class HttpKeyStore : public KeyStore {
+ public:
+  using Validator = std::function<bool(const std::string& key)>;
+
+  explicit HttpKeyStore(Validator fn) : fn_(std::move(fn)) {}
+
+  bool validate(const std::string& key) override { return fn_(key); }
+
+ private:
+  Validator fn_;
+};
+
+/// Factory — builds an HttpKeyStore that POSTs `{"key": "..."}` to
+/// `{endpoint}` and interprets a JSON body of the form `{"valid": bool,...}`.
+///
+/// - `timeoutSeconds`: hard timeout per request. Default 3 s.
+/// - Any non-200 response, timeout, DNS error, or JSON parse failure is
+///   treated as INVALID (fail closed).
+///
+/// Defined in `src/HttpKeyStoreFactory.cpp` so that tests and callers that
+/// only need the class body avoid pulling in the cpp-httplib / OpenSSL
+/// dependencies.
+HttpKeyStore makeHttpKeyStoreFromEndpoint(const std::string& endpoint,
+                                           int timeoutSeconds = 3);
+
+}  // namespace beepbox
+
+#endif  // BEEPBOX_HTTP_KEY_STORE_H

--- a/src/HttpKeyStoreFactory.cpp
+++ b/src/HttpKeyStoreFactory.cpp
@@ -1,0 +1,67 @@
+// Server-only implementation of the HttpKeyStore factory.
+// Pulls in cpp-httplib (HTTPS client) and jsoncpp (response parsing).
+// Kept out of the core library so tests don't need OpenSSL/jsoncpp.
+
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include <httplib.h>
+#include <json/json.h>
+
+#include <sstream>
+#include <stdexcept>
+
+#include "beepbox/HttpKeyStore.h"
+
+namespace beepbox {
+
+namespace {
+
+/// Splits "https://host/path" into ("https://host", "/path").
+/// If `url` has no path beyond the host, returns ("https://host", "/").
+std::pair<std::string, std::string> splitEndpoint(const std::string& url) {
+  auto schemeEnd = url.find("://");
+  if (schemeEnd == std::string::npos) {
+    throw std::invalid_argument(
+        "makeHttpKeyStoreFromEndpoint: endpoint must be a full URL");
+  }
+  auto pathStart = url.find('/', schemeEnd + 3);
+  if (pathStart == std::string::npos) return {url, "/"};
+  return {url.substr(0, pathStart), url.substr(pathStart)};
+}
+
+}  // namespace
+
+HttpKeyStore makeHttpKeyStoreFromEndpoint(const std::string& endpoint,
+                                           int timeoutSeconds) {
+  auto [base, path] = splitEndpoint(endpoint);
+  return HttpKeyStore([base, path, timeoutSeconds](
+                          const std::string& key) -> bool {
+    try {
+      httplib::Client client(base.c_str());
+      client.set_connection_timeout(timeoutSeconds, 0);
+      client.set_read_timeout(timeoutSeconds, 0);
+      client.set_write_timeout(timeoutSeconds, 0);
+      client.enable_server_certificate_verification(true);
+
+      Json::Value body(Json::objectValue);
+      body["key"] = key;
+      Json::StreamWriterBuilder writer;
+      writer.settings_["indentation"] = "";
+      const std::string bodyStr = Json::writeString(writer, body);
+
+      auto res = client.Post(path.c_str(), bodyStr, "application/json");
+      if (!res || res->status != 200) return false;
+
+      Json::CharReaderBuilder reader;
+      Json::Value root;
+      std::string errs;
+      std::istringstream iss(res->body);
+      if (!Json::parseFromStream(reader, iss, &root, &errs)) return false;
+      return root.isMember("valid") && root["valid"].isBool() &&
+             root["valid"].asBool();
+    } catch (...) {
+      return false;
+    }
+  });
+}
+
+}  // namespace beepbox

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -5,6 +5,7 @@
 #include "beepbox/WavWriter.h"
 #include "beepbox/WavReader.h"
 #include "beepbox/ApiKeyAuth.h"
+#include "beepbox/HttpKeyStore.h"
 #include "beepbox/RateLimiter.h"
 #include "beepbox/Metrics.h"
 #include "beepbox/Tracing.h"
@@ -13,6 +14,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <algorithm>
 #include <vector>
@@ -32,8 +34,10 @@ using namespace drogon;
 // --- Metrics collector (initialized in main) ---
 static beepbox::MetricsCollector* g_metrics = nullptr;
 
-// Shared auth state (initialized in main)
-static beepbox::EnvKeyStore* g_keyStore = nullptr;
+// Shared auth state (initialized in main). Backed by an abstract KeyStore so
+// we can swap in EnvKeyStore (dev), HttpKeyStore (prod, via Cloud Function),
+// or future stores without touching request handlers.
+static beepbox::KeyStore* g_keyStore = nullptr;
 static beepbox::KeyCache* g_keyCache = nullptr;
 static bool g_authEnabled = false;
 
@@ -91,20 +95,44 @@ static bool checkRateLimit(
 
 int main() {
   // --- Auth setup ---
-  static beepbox::EnvKeyStore keyStore;
+  //
+  // Priority order:
+  //   1. BEEPBOX_AUTH_ENDPOINT (URL) → HttpKeyStore backed by a Cloud
+  //      Function validator + Firestore. Used in prod/dev envs.
+  //   2. BEEPBOX_API_KEYS (CSV list) → EnvKeyStore. Used for local dev /
+  //      smoke tests.
+  //   3. Neither set → auth disabled (warning logged, permissive).
   static beepbox::KeyCache keyCache;
-  g_keyStore = &keyStore;
   g_keyCache = &keyCache;
-  g_authEnabled = !keyStore.empty();
+
+  static std::unique_ptr<beepbox::KeyStore> keyStorePtr;
+  const char* authEndpoint = std::getenv("BEEPBOX_AUTH_ENDPOINT");
+  const char* envKeys = std::getenv("BEEPBOX_API_KEYS");
+
+  if (authEndpoint && authEndpoint[0] != '\0') {
+    keyStorePtr = std::make_unique<beepbox::HttpKeyStore>(
+        beepbox::makeHttpKeyStoreFromEndpoint(authEndpoint));
+    g_keyStore = keyStorePtr.get();
+    g_authEnabled = true;
+    std::cout << "API key authentication enabled (HTTP validator: "
+              << authEndpoint << ")\n";
+  } else if (envKeys && envKeys[0] != '\0') {
+    keyStorePtr = std::make_unique<beepbox::EnvKeyStore>();
+    g_keyStore = keyStorePtr.get();
+    g_authEnabled =
+        !static_cast<beepbox::EnvKeyStore*>(keyStorePtr.get())->empty();
+    if (g_authEnabled) {
+      std::cout << "API key authentication enabled (env keys)\n";
+    }
+  }
 
   // --- Metrics setup ---
   static beepbox::MetricsCollector metricsCollector;
   g_metrics = &metricsCollector;
 
-  if (g_authEnabled) {
-    std::cout << "API key authentication enabled\n";
-  } else {
-    std::cout << "WARNING: BEEPBOX_API_KEYS not set — auth disabled (dev mode)\n";
+  if (!g_authEnabled) {
+    std::cout << "WARNING: neither BEEPBOX_AUTH_ENDPOINT nor BEEPBOX_API_KEYS "
+                 "set — auth disabled (dev mode)\n";
   }
 
   // --- Rate limiter setup ---

--- a/tests/HttpKeyStoreTests.cpp
+++ b/tests/HttpKeyStoreTests.cpp
@@ -1,0 +1,40 @@
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+
+#include "beepbox/HttpKeyStore.h"
+
+using beepbox::HttpKeyStore;
+
+TEST_CASE("HttpKeyStore: valid result returns true",
+          "[auth][http-store]") {
+  HttpKeyStore store([](const std::string& key) -> bool {
+    return key == "bk_good";
+  });
+  REQUIRE(store.validate("bk_good"));
+  REQUIRE(!store.validate("bk_other"));
+}
+
+TEST_CASE("HttpKeyStore: validator receives the raw key",
+          "[auth][http-store]") {
+  std::string captured;
+  HttpKeyStore store([&captured](const std::string& key) -> bool {
+    captured = key;
+    return true;
+  });
+  store.validate("bk_abc123");
+  REQUIRE(captured == "bk_abc123");
+}
+
+TEST_CASE("HttpKeyStore: forwards every call (no internal cache)",
+          "[auth][http-store]") {
+  std::atomic<int> calls{0};
+  HttpKeyStore store([&calls](const std::string&) -> bool {
+    calls.fetch_add(1);
+    return true;
+  });
+  store.validate("bk_same");
+  store.validate("bk_same");
+  store.validate("bk_other");
+  // KeyCache handles caching; HttpKeyStore does not.
+  REQUIRE(calls.load() == 3);
+}


### PR DESCRIPTION
## Summary

Adds a second \`KeyStore\` impl that validates \`bk_\` keys via a remote HTTPS endpoint (a Firebase Cloud Function backed by Firestore). Priority: if \`BEEPBOX_AUTH_ENDPOINT\` is set → HttpKeyStore; else fallback to \`BEEPBOX_API_KEYS\` env list; else auth disabled.

## Changes

- \`include/beepbox/HttpKeyStore.h\` — header-only class with injectable \`Validator = std::function<bool(string)>\`. Testable without HTTP/OpenSSL.
- \`src/HttpKeyStoreFactory.cpp\` — \`makeHttpKeyStoreFromEndpoint()\` backed by cpp-httplib (v0.18.3) + jsoncpp. Fail-closed on network/timeout/5xx.
- \`src/server_main.cpp\` — KeyStore pointer is now abstract \`KeyStore*\`, swappable at init. Wires HttpKeyStore when \`BEEPBOX_AUTH_ENDPOINT\` is set.
- \`tests/HttpKeyStoreTests.cpp\` — 3 unit tests via injected validators.
- \`CMakeLists.txt\` — FetchContent cpp-httplib + find_package(OpenSSL).
- \`docs/observability.md\` — document env vars with fallback semantics.
- \`.gitignore\` — ignore \`.cache/\` (clangd index).

## Why

Unblocks BEE-1686 (quest step 4 — developer hits \`/v1/encode\` with their real \`bk_\` key). Companion CF \`validateApiKey\` lives in \`beeping-io/beeping-www/functions/\` (to be deployed).

## Test plan

- [ ] CI green on Linux/macOS
- [ ] HttpKeyStore tests (3) pass
- [ ] Existing ApiKeyAuth tests still pass (no regression)
- [ ] Manual: curl against dev beepbox with new env var + real key

Linked: BEE-1687