### PR TITLE
chore(repo): BEE-2277 README rewrite + gitleaks audit + history redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,64 @@
 # BeepBox
 
-BeepBox is Beeping’s CLI tool to generate or embed acoustic marks (beeps) into WAV files. It relies on **Beeping Core** to synthesize marks and supports audible, hidden, non-audible, and custom modes. It transports identifier data through audio in a robust way.
+BeepBox is Beeping's **HTTP server and CLI tool** to generate or embed acoustic marks (beeps) into WAV files. It relies on **Beeping Core** to synthesize marks and supports audible, hidden, non-audible, and custom modes. It transports identifier data through audio in a robust way.
+
+<!-- Identity -->
+![License](https://img.shields.io/badge/License-Apache_2.0-blue)
+![status](https://img.shields.io/badge/status-early_development-orange)
+![platform](https://img.shields.io/badge/platform-Beeping-purple)
+![conventional commits](https://img.shields.io/badge/conventional_commits-1.0.0-yellow)
+
+<!-- Tech stack -->
+![C++](https://img.shields.io/badge/C++-20-00599C?logo=cplusplus&logoColor=white)
+![CMake](https://img.shields.io/badge/CMake-3.25+-064F8C?logo=cmake&logoColor=white)
+![Drogon](https://img.shields.io/badge/Drogon-HTTP_framework-2D9CDB)
+
+<!-- CI -->
+[![Build & Test](https://github.com/beeping-io/beepbox/actions/workflows/ci.yml/badge.svg)](https://github.com/beeping-io/beepbox/actions/workflows/ci.yml)
+[![Docker](https://github.com/beeping-io/beepbox/actions/workflows/docker-build.yml/badge.svg)](https://github.com/beeping-io/beepbox/actions/workflows/docker-build.yml)
+[![Deploy](https://github.com/beeping-io/beepbox/actions/workflows/deploy.yml/badge.svg)](https://github.com/beeping-io/beepbox/actions/workflows/deploy.yml)
+[![OpenAPI Clients](https://github.com/beeping-io/beepbox/actions/workflows/openapi-clients.yml/badge.svg)](https://github.com/beeping-io/beepbox/actions/workflows/openapi-clients.yml)
+
+The same repo produces two consumption shapes:
+
+- **HTTP server** (`beepbox_server`) — REST API at `/v1/encode` and `/v1/decode`, used by SDK wrappers (Android, iOS, web) and any client over the wire. Drogon-based, with API-key auth via a Firestore-backed `HttpKeyStore`, CORS allowlist, rate limiting, OpenTelemetry tracing and Prometheus metrics.
+- **CLI** (`BeepBox`) — host-side WAV generation/mixing for batch jobs, demos and tests. The flags below cover the CLI surface.
 
 ## Installation / Build
-- Dependencies: CMake, C++ compiler, `libsndfile` (system), `libebur128` (FetchContent), Beeping Core (FetchContent).
+- Dependencies: CMake, C++ compiler, `libsndfile` (system), `libebur128` (FetchContent), Beeping Core (FetchContent), Drogon (FetchContent, server only).
 - Steps:
   ```bash
   cmake -S . -B build
   cmake --build build
   cmake --install build   # optional, installs into ./bin and ./lib in the repo
   ```
-- Binary: `build/BeepBox` (or `bin/BeepBox` after install).
+- Binaries: `build/BeepBox` (CLI) and `build/beepbox_server` (HTTP server).
 
-## Basic usage
+## HTTP server
+
+Run the server locally:
+
+```bash
+./build/beepbox_server  # binds 0.0.0.0:8080 by default
+```
+
+Smoke test (audible WAV at `/v1/encode`, requires a valid API key):
+
+```bash
+curl -X POST -H "Authorization: Bearer bk_..." \
+  -H "Content-Type: application/json" \
+  -d '{"key":"abcde","mode":"audible"}' \
+  http://localhost:8080/v1/encode --output beep.wav
+```
+
+Endpoints, request/response shapes and error codes are documented in:
+
+- [`docs/api/reference.md`](docs/api/reference.md) — human-readable reference
+- [`docs/api/openapi.yaml`](docs/api/openapi.yaml) — OpenAPI 3.0 spec (used by the `openapi-clients` workflow to generate SDK stubs)
+
+Operational docs live under [`docs/ops/`](docs/ops/) (deploy, infrastructure, environments, supply-chain) and [`docs/observability/`](docs/observability/) (metrics, tracing).
+
+## Basic usage (CLI)
 Minimal command (generates 1 beep by default):
 ```bash
 ./build/BeepBox -k 00001 -o output.wav
@@ -77,3 +123,31 @@ Defaults: `duration=2.3s`, `interval=2.3s`, `start=0`, mode `non-audible` (2), s
   ```bash
   BeepBox -n -k 00001 -o plan.wav -d 10 -i 2.5
   ```
+
+## Community
+
+### Chat & support
+
+- 💬 **Discord** — [chat with the team and other developers](https://discord.gg/beeping)
+- 💼 **Slack** — coming soon (will be cross-bridged with Discord)
+- 🐛 **Issues** — [github.com/beeping-io/beepbox/issues](https://github.com/beeping-io/beepbox/issues) for bugs and feature requests
+
+### Follow us
+
+Social handles coming soon — see the issue tracker for status.
+
+- 🐦 X (Twitter) · 💼 LinkedIn · 📸 Instagram · 🎵 TikTok · 📺 YouTube · 🐘 Mastodon · 🦋 Bluesky
+
+### Project governance
+
+- 🛡️ **Security** — formal `SECURITY.md` disclosure policy is on the way; in the meantime, please email security at beeping dot io for vulnerability reports
+- 🤝 **Contributing** — formal `CONTRIBUTING.md` is on the way; the project uses conventional commits, semantic-release via `release-please`, and PRs against `develop`
+
+Beeping is built in the open. BeepBox is the HTTP server and CLI; the C++20
+synthesis/decoding library lives in [`beeping-core`](https://github.com/beeping-io/beeping-core),
+and SDK wrappers + the marketing site live in the sibling repos of the
+[`beeping-io`](https://github.com/beeping-io) org.
+
+## License
+
+[Apache-2.0](LICENSE)

--- a/docs/security/gitleaks-2026-05-18.md
+++ b/docs/security/gitleaks-2026-05-18.md
@@ -1,0 +1,115 @@
+# 🛡️ Secrets-leak audit · 2026-05-18
+
+> Performed as part of BEE-2277 (Phase 1 · 📡 Make `beepbox` public —
+> README + LICENSE audit + topics + secrets hygiene).
+
+## Tool
+
+[`gitleaks`](https://github.com/gitleaks/gitleaks) (Homebrew install, default ruleset)
+plus [`git-filter-repo`](https://github.com/newren/git-filter-repo) v2.47.0
+for history rewriting.
+
+## Initial scan — findings
+
+Working tree + full git history (`--log-opts="--all"`).
+
+```bash
+gitleaks detect --source . --no-banner --log-opts="--all"
+```
+
+```text
+62 commits scanned.
+scanned ~582133 bytes (582.13 KB) in ~140ms
+WRN leaks found: 2
+```
+
+Two hits to the `generic-api-key` rule, both on `docs/PENDING.md:65`, in
+commits `ee7f69f` (original) and `edfd59d` (the merged PR #11), authored
+2026-05-16 during the `v0.1.0` deploy follow-up capture.
+
+## Risk assessment
+
+The leaked string is the test API key referenced in `pending-003` (test
+keys minted in BEE-1802 for SDK E2E suites). Verified out-of-band against
+the live `/v1/encode` endpoints:
+
+| Environment                                | Leaked key result              |
+| ------------------------------------------ | ------------------------------ |
+| `https://beepbox-dev.beeping.io/v1/encode` | HTTP 403 — Invalid API key     |
+| `https://beepbox.beeping.io/v1/encode`     | HTTP 403 — Invalid API key     |
+
+The leaked key was **already dead** at audit time — `pending-003` had
+documented this state on 2026-05-16. Live SDK E2E keys are stored in
+`beeping-android/.env.local` / `beeping-ios/.env.local` (gitignored) and
+are **different** from the leaked value. Out-of-band fingerprint checks
+confirmed the live keys do not appear anywhere in git history.
+
+Even though the leaked secret was already revoked / never properly
+registered, exposing secret-shape strings in a soon-to-be-public history
+fails auditor expectations and gives attackers structural information.
+Therefore the leak was redacted from history before flipping the repo to
+public.
+
+## Mitigation — `git filter-repo`
+
+```bash
+git filter-repo --replace-text /tmp/beepbox-redactions.txt --force
+```
+
+The redaction file contained the single unique leaked secret value with
+the substitution `==> [REDACTED-BEEPBOX-API-KEY]`. After rewrite:
+
+- `develop` HEAD moved from `edfd59d` → `6bef33d`
+- Tags `v0.0.0`, `v0.1.0`, `1.0.0`, `1.1.0` were also rewritten and
+  force-pushed
+- All sibling branches (`chore/pending-deploy-followups`,
+  `milestone/phase-2-beepbox`, `release-please--branches--develop`) were
+  rewritten and force-pushed
+- The post-rewrite working tree shows `[REDACTED-BEEPBOX-API-KEY]` at
+  `docs/PENDING.md:65` instead of the secret value
+
+## Post-rewrite verification
+
+```bash
+gitleaks detect --source . --no-banner --log-opts="--all"
+```
+
+```text
+62 commits scanned.
+scanned ~582135 bytes (582.14 KB) in ~85ms
+INF no leaks found
+```
+
+**Result: 0 leaks.** Repo is clean to be exposed publicly.
+
+## Known orphaned commits on GitHub
+
+GitHub retains orphaned commits accessible by SHA for ~90 days after
+they become unreachable. The pre-rewrite SHAs (`ee7f69f`, `edfd59d`,
+old tag targets, etc.) may still be fetchable by an attacker who knows
+the SHA, until GitHub's GC removes them. Since the leaked key was
+already dead at audit time, this orphan window is **harmless**.
+
+If `pending-003` ever turns out to be wrong and the leaked key was live
+at some point during the orphan window, the residual risk is bounded
+because Firestore would still return HTTP 403 for that key (it has no
+matching active hash document).
+
+## Cadence
+
+Re-run gitleaks before any major release or whenever a new branch is
+merged that touches `docs/`, configuration, CI or build scripts. A CI
+gitleaks job is a sensible follow-up (out of scope for this PR; tracked
+informally as a future hardening pass).
+
+## Verification by reviewers
+
+To reproduce locally on this rewritten history:
+
+```bash
+brew install gitleaks   # or apt/snap/winget equivalents
+cd beepbox
+gitleaks detect --source . --no-banner --log-opts="--all"
+```
+
+Expected output: `no leaks found`.


### PR DESCRIPTION
## Summary

- Audit cleanup of `beepbox` ahead of flipping the repo public (Phase 1 of the `beeping-www` milestone).
- README previously described only the CLI; it now leads with the **HTTP server + CLI** dual shape, exposes the canonical badge row (License, status, conventional commits, C++20, CMake, Drogon, CI workflows) and gains a new **HTTP server quick-start** section linked to `docs/api/reference.md` and `docs/api/openapi.yaml`.
- **gitleaks** audit found 2 hits to a stale BEE-1802 test API key inside `docs/PENDING.md`. The leaked value was already dead (`HTTP 403` against both `/v1/encode` envs at audit time) but the secret-shape was redacted from full history via `git filter-repo --replace-text`. `develop`, tags (`v0.0.0`, `v0.1.0`, `1.0.0`, `1.1.0`) and sibling branches were force-pushed with the rewritten objects.

## History rewrite — important for reviewers

`develop` HEAD moved from `edfd59d` → `6bef33d`. If you had a local clone before this PR, **you need to re-fetch and reset**:

```bash
git fetch origin
git checkout develop
git reset --hard origin/develop
```

The old SHAs remain orphaned on GitHub for ~90 days (until GC). Since the leaked key was already dead, this orphan window is harmless. Full audit report: [`docs/security/gitleaks-2026-05-18.md`](docs/security/gitleaks-2026-05-18.md).

## GitHub-side metadata (applied live, not in this diff)

- 🔗 **Homepage** → `https://github.com/beeping-io/beepbox`
- 🏷️ **9 topics** → `audio`, `cli`, `cmake`, `cpp20`, `data-over-sound`, `drogon`, `http-server`, `rest-api`, `ultrasonic`

## Visibility flip — NOT in this PR

The actual flip from PRIVATE → PUBLIC is held back until founder approves it explicitly after reviewing this PR. To flip post-merge:

```bash
gh repo edit beeping-io/beepbox --visibility public
```

## Linear

Closes **BEE-2277** (moves to Done after the flip).

Cross-task impact:
- The **README placeholders** for SECURITY.md / CONTRIBUTING.md / formal social handles are resolved by **BEE-2274** (governance docs cross-repo) and **BEE-2216** (social accounts launch), both later in Phase 1.
- The previous `pending-003` of this repo is **no longer accurate** — its premise was that test API keys returned 403 (true at the time of writing) but the production live keys remain working in `beeping-android/.env.local` and `beeping-ios/.env.local`. Recommend re-triaging `pending-003` separately.

## Test plan

- [x] `gitleaks detect --source . --no-banner --log-opts="--all"` (post-filter) → no leaks
- [x] `npx markdownlint-cli2 README.md docs/security/gitleaks-2026-05-18.md` → 0 errors
- [x] Live-test against `/v1/encode` confirmed leaked key returns HTTP 403 in both dev and prod
- [x] `gh repo view` confirms homepage + 9 topics applied
- [ ] CI on this PR (Build & Test + Docker + Deploy + OpenAPI Clients) — must pass before merge
- [ ] Founder approval to flip `--visibility public` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)