### PR TITLE
docs(readme): link the 3 community channels (GitHub Discussions, Slack, Discord)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ synthesis/decoding library lives in [`beeping-core`](https://github.com/beeping-
 and SDK wrappers + the marketing site live in the sibling repos of the
 [`beeping-io`](https://github.com/beeping-io) org.
 
+## 💬 Community
+
+Have a question, idea or showcase? Three places to talk:
+
+- **GitHub Discussions** — async forum, indexable: <https://github.com/beeping-io/.github/discussions>
+- **Slack** — real-time chat: [join the workspace](https://join.slack.com/t/beeping-io/shared_invite/zt-3yv2kc6qs-tWxx1AViHgdEembSPqm26Q)
+- **Discord** — same channels, Discord flavour: <https://discord.gg/XNPXdZK7>
+
+Code of Conduct (Contributor Covenant 2.1): <https://github.com/beeping-io/.github/blob/main/CODE_OF_CONDUCT.md>
+
 ## License
 
 [Apache-2.0](LICENSE)


### PR DESCRIPTION
Adds a `💬 Community` section to the README (GitHub Discussions, Slack on the new beeping-io.slack.com workspace, Discord) + Code of Conduct. Part of BEE-2297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)